### PR TITLE
! add graphql endpoint query support

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -27,6 +27,7 @@ declare namespace NodeJS {
   }
   interface ProcessEnv {
     NODE_ENV: 'test' | 'development' | 'production'
+    READONLY: 'true' | 'false'
   }
   interface Process {
     browser: boolean

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -46,7 +46,9 @@ export class InnerApp extends React.PureComponent<{
     return (
       <React.StrictMode>
         <ApolloProvider
-          client={apolloClient || initApolloClient(apolloClientState as any)}
+          client={
+            apolloClient || initApolloClient(apolloClientState as any, url)
+          }
         >
           <DataLoadingProvider contextValue={contextValue}>
             <ResumeProvider>
@@ -84,7 +86,7 @@ export default class MyApp extends App<{
     }
 
     const dataLoadingContextValue = new DataLoading()
-    const apolloClient = initApolloClient()
+    const apolloClient = initApolloClient(undefined, url)
 
     if (!process.browser) {
       logger.debug('[_app] starting ssr (server)')


### PR DESCRIPTION
this can be used by passing in `graphql` as a search param

for example
`http://localhost:3000/?graphql=https://modern-stack-resume-graphql-4afts4tal.now.sh/graphql`