### PR TITLE
Redesign/style experience item page

### DIFF
--- a/src/AppStyles.tsx
+++ b/src/AppStyles.tsx
@@ -20,10 +20,10 @@ export const aboutMePageDarkStyles = css`
   --theme-about-me-divider-bottom: #000;
   --theme-skills-background: var(--color-dark-background-dark-surface);
   --theme-skills-color: #fff;
-  --theme-skills-item-background: #000;
+  --theme-skills-item-background: rgba(18, 18, 18, 0.9);
   --theme-skills-item-color: #fff;
   --theme-label-color: #bb86fc;
-  --theme-about-me-article-background: #000;
+  --theme-about-me-article-background: rgba(0, 0, 0, 0.8);
   --theme-header-background: rgba(0, 0, 0, 0.35);
   --theme-about-me-image-shadow: '0 1rem 0.75rem rgb(0 0 0 / 19%), 0 0.5rem 0.5rem rgb(0 0 0 / 23%)';
   --theme-about-me-article-color: rgba(255, 255, 255, 1);
@@ -35,12 +35,12 @@ export const aboutMePageLightStyles = css`
   --theme-about-me-divider-bottom: #000;
   --theme-about-me-separator-top: #bbb;
   --theme-about-me-separator-bottom: #aaa;
-  --theme-skills-background: #fff;
+  --theme-skills-background: rgba(255, 255, 255, 0.9);
   --theme-skills-color: #1b1b1b;
   --theme-skills-item-background: #eee;
   --theme-skills-item-color: #1b1b1b;
   --theme-label-color: #232f34;
-  --theme-about-me-article-background: #fff;
+  --theme-about-me-article-background: rgba(255, 255, 255, 0.9);
   --theme-about-me-article-color: #000;
   --theme-about-me-image-shadow: '0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12)';
 `
@@ -77,7 +77,7 @@ const appStylesUglified = css`
     --color-material-background-purple: #6200ee;
     --color-text-secondary: #03dac6;
     --color-orange: #ff5722;
-    --color-dark-background-dark-surface: #121212;
+    --color-dark-background-dark-surface: rgba(18, 18, 18, 0.9);
     --color-link: #fff;
     --color-link-hover: #aaa;
     --color-text-body: #fff;
@@ -100,6 +100,7 @@ const appStylesUglified = css`
   }
   [role='banner'] {
     position: absolute;
+    z-index: 5;
   }
 
   @font-face {
@@ -164,6 +165,7 @@ const appStylesUglified = css`
     line-height: 1.5;
   }
   #__next {
+    position: relative;
     min-height: inherit;
     background-color: var(--theme-page-background);
     display: flex;

--- a/src/AppStyles.tsx
+++ b/src/AppStyles.tsx
@@ -15,16 +15,17 @@ import { createGlobalStyle, css } from 'styled-components'
  * --color-text-unimportant-bad-contrast: #6c757d;
  */
 
+/** @todo verify color contrast is sufficient for accessibility while using glassmorphism */
 export const aboutMePageDarkStyles = css`
   --theme-about-me-divider-top: var(--color-text-secondary);
   --theme-about-me-divider-bottom: #000;
-  --theme-skills-background: var(--color-dark-background-dark-surface);
+  --theme-skills-background: rgba(18, 18, 18, 0.4);
   --theme-skills-color: #fff;
   --theme-skills-item-background: rgba(18, 18, 18, 0.9);
   --theme-skills-item-color: #fff;
   --theme-label-color: #bb86fc;
   --theme-about-me-article-background: rgba(0, 0, 0, 0.8);
-  --theme-header-background: rgba(0, 0, 0, 0.35);
+  --theme-header-background: rgba(0, 0, 0, 0.7);
   --theme-about-me-image-shadow: '0 1rem 0.75rem rgb(0 0 0 / 19%), 0 0.5rem 0.5rem rgb(0 0 0 / 23%)';
   --theme-about-me-article-color: rgba(255, 255, 255, 1);
   --theme-about-me-separator-top: #fefefe;
@@ -68,7 +69,7 @@ export const darkColorStyles = css`
   --theme-card-header: var(--color-text-secondary);
   --theme-card-background: #344955;
   --theme-selection-background: #bb86fc;
-  --theme-footer-background: var(--color-dark-background-dark-surface);
+  --theme-footer-background: rgba(18, 18, 18, 0.9);
   --theme-page-background: #232f34;
 `
 
@@ -77,7 +78,6 @@ const appStylesUglified = css`
     --color-material-background-purple: #6200ee;
     --color-text-secondary: #03dac6;
     --color-orange: #ff5722;
-    --color-dark-background-dark-surface: rgba(18, 18, 18, 0.9);
     --color-link: #fff;
     --color-link-hover: #aaa;
     --color-text-body: #fff;

--- a/src/features/Footer/Footer.tsx
+++ b/src/features/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import type { OpenSourceType } from '../../typings'
+import type { OpenSourceType, ProfileType } from '../../typings'
 import {
   StyledFooter,
   MadeWithText,
@@ -12,8 +12,12 @@ import {
 export default React.memo(function Footer({
   name,
   openSource,
+  profiles,
+  resumeWebsite,
   ...props
 }: {
+  profiles?: ProfileType[]
+  resumeWebsite?: string
   openSource: OpenSourceType
   className?: string
   name?: string
@@ -35,7 +39,13 @@ export default React.memo(function Footer({
           github.com/aretecode
         </OpenSourceLink>
       </p>
-      <StyledSocialProfiles />
+      {resumeWebsite && profiles && (
+        <StyledSocialProfiles
+          profiles={profiles}
+          resumeWebsite={resumeWebsite}
+          key="profiles"
+        />
+      )}
     </StyledFooter>
   )
 })

--- a/src/features/Navigation/Navigation.tsx
+++ b/src/features/Navigation/Navigation.tsx
@@ -6,7 +6,7 @@ export default React.memo(function HeaderNavigation(props: {
   className?: string
 }) {
   return (
-    <StyledNav {...props}>
+    <StyledNav {...props} role="navigation" aria-label="Main pages">
       <StyledNavList>
         <li>
           <StyledLink to="/Portfolio" rel="me">

--- a/src/features/Picture/Picture.tsx
+++ b/src/features/Picture/Picture.tsx
@@ -29,17 +29,18 @@ const toNextUrl = (srcUrl: string, srcWidth?: number | string) => {
 
 export default function ResponsiveImage({
   image,
-  className,
   RenderImage = ImageComponent,
+  RenderPicture = PictureWithAmpSupport,
+  ...rest
 }: {
   image: ImageObjectType
-  className?: string
   RenderImage?: React.FC<React.ComponentProps<typeof ImageComponent>>
-}) {
+  RenderPicture?: React.FC<React.ComponentProps<typeof PictureWithAmpSupport>>
+} & Partial<React.ComponentProps<typeof StyledPicture>>) {
   const isAmp = useAmp()
 
   return (
-    <PictureWithAmpSupport className={className}>
+    <RenderPicture {...rest}>
       {!isAmp &&
         image.srcSizes.map(([size, srcSet, srcWidth]) => (
           <source
@@ -56,6 +57,6 @@ export default function ResponsiveImage({
         alt={image.description}
         srcSizes={image.srcSizes}
       />
-    </PictureWithAmpSupport>
+    </RenderPicture>
   )
 }

--- a/src/features/SocialProfiles/styled.ts
+++ b/src/features/SocialProfiles/styled.ts
@@ -24,6 +24,7 @@ export const StyledSocialProfilesWrap = styled.aside`
   object-position: bottom;
   display: flex;
   max-width: 100%;
+  background: transparent;
 
   @media (max-width: 1023px) {
     width: 75%;

--- a/src/features/SocialProfiles/styled.ts
+++ b/src/features/SocialProfiles/styled.ts
@@ -13,12 +13,16 @@ export const StyledSocialProfileIcon = styled(MaterialIcon)`
 `
 
 /**
+ * @semantic aside @todo accessibility says this can only be top level as an aside
  * @see https://material.io/design/motion/speed.html#easing
  * @todo when transitioning mobile to desktop, needs to morph
  * @note `order` is here because nothing is currently reused, would style in the page or larger component
  * @todo   transition: flex-direction 0.24s cubic-bezier(0, 0, 0.2, 1), width 0.24s cubic-bezier(0, 0, 0.2, 1);
  */
-export const StyledSocialProfilesWrap = styled.aside`
+export const StyledSocialProfilesWrap = styled.nav.attrs({
+  'data-role': 'aside',
+  'aria-label': 'Social profiles',
+})`
   align-items: center;
   object-fit: contain;
   object-position: bottom;

--- a/src/pages/About/Skills.tsx
+++ b/src/pages/About/Skills.tsx
@@ -3,10 +3,14 @@ import styled, { css } from 'styled-components'
 import { AnimateHeight } from '../../features/AnimateHeight/AnimateHeight'
 
 /**
+ * @semantic aside @todo accessibility says this can only be top level as an aside
  * @todo split out
  * @see StyledSocialProfilesWrap for related `order` comments
  */
-export const StyledSkillsWrap = styled.aside`
+export const StyledSkillsWrap = styled.section.attrs({
+  'data-role': 'aside',
+  'aria-label': 'Skills',
+})`
   overflow: hidden;
   transition: background-color 0.24s cubic-bezier(0.4, 0, 0.2, 1),
     color 0.24s cubic-bezier(0.4, 0, 0.2, 1),

--- a/src/pages/About/amp/AmpSkills.tsx
+++ b/src/pages/About/amp/AmpSkills.tsx
@@ -5,7 +5,7 @@ import { StyledSkillsWrap, StyledSkillItem, StyledSkillList } from '../Skills'
 export function Skills({ skills }: { skills: string[] }) {
   return (
     <AmpAnimateHeight>
-      <StyledSkillsWrap>
+      <StyledSkillsWrap as="aside">
         <StyledSkillList>
           {skills.map(x => (
             <StyledSkillItem key={x}>{x}</StyledSkillItem>

--- a/src/pages/About/amp/AmpStyles.tsx
+++ b/src/pages/About/amp/AmpStyles.tsx
@@ -72,12 +72,12 @@ export default createGlobalStyle`
     position: unset;
   }
   @media (max-width: 1023px) {
-    ${StyledAboutMeArticle} > aside {
+    ${StyledAboutMeArticle} > [data-role="aside"] {
       width: 100%;
     }
   }
   ${pureAccordionStyles};
   amp-accordion ${StyledButtonWrap} { margin-top: unset; }
-  amp-accordion, amp-accordion > section > aside { max-width: 100%; }
+  amp-accordion, amp-accordion > section > [data-role="aside"] { max-width: 100%; }
 
 `

--- a/src/pages/About/amp/AmpStyles.tsx
+++ b/src/pages/About/amp/AmpStyles.tsx
@@ -56,7 +56,7 @@ export default createGlobalStyle`
       ${aboutMePageDarkStyles};
     }
     amp-accordion > section > header.amp-accordion-header {
-      background-color: var(--color-dark-background-dark-surface);
+      background-color: var(--theme-footer-background);
       border-width: 4px;
     }
   }

--- a/src/pages/About/styled.tsx
+++ b/src/pages/About/styled.tsx
@@ -14,18 +14,22 @@ import { webpBackgroundStyles } from '../../features/BackgroundStyles'
 
 export const GlobalPageStyles = createGlobalStyle`
   ${aboutMePageDynamicColorStyles};
+  #__next {
+    ${webpBackgroundStyles};
+  }
 `
 
-export const StyledAboutMeMain = styled(StyledMain)`
-  ${webpBackgroundStyles};
-`
+export const StyledAboutMeMain = styled(StyledMain)``
 export const StyledHeader = styled(Header)``
-export const StyledFooter = styled(Footer)``
+export const StyledFooter = styled(Footer)`
+  background-color: var(--theme-header-background);
+`
 export const StyledLink = styled(Link)`
   &&& {
     color: unset;
     text-decoration: initial;
     letter-spacing: initial;
+    word-break: normal;
   }
 `
 

--- a/src/pages/About/styled.tsx
+++ b/src/pages/About/styled.tsx
@@ -247,13 +247,20 @@ export const StyledContactNav = styled.nav`
 export const StyledAboutMeArticle = styled.article`
   background-color: var(--theme-about-me-article-background);
   color: var(--theme-about-me-article-color);
-
   margin: 9rem 1rem 9rem 1rem;
   border-radius: 0.125rem;
   box-shadow: var(--theme-about-me-image-shadow);
-
   display: flex;
   flex-wrap: wrap;
+
+  backdrop-filter: blur(10px);
+  *,
+  nav,
+  > article,
+  > ${StyledFigure}, > ${StyledFigure} > ${StyledFigCaption} {
+    background-color: transparent;
+  }
+
   @media (min-width: 1201px) {
     width: 90%;
   }

--- a/src/pages/Portfolio/AmpStyles.tsx
+++ b/src/pages/Portfolio/AmpStyles.tsx
@@ -11,7 +11,6 @@ export default createGlobalStyle`
   figure > figcaption {
     padding-top: 20%;
   }
-
   @media (prefers-color-scheme: dark) {
     ${darkColorStyles};
     :root {

--- a/src/pages/Portfolio/ExperiencePage.tsx
+++ b/src/pages/Portfolio/ExperiencePage.tsx
@@ -1,15 +1,136 @@
 import * as React from 'react'
+import styled, { css } from 'styled-components'
 import { useRouter } from 'next/router'
 import PortfolioSchema from '../../features/PortfolioSchema'
 import PortfolioHead from '../../features/PortfolioHead'
 import { StyledMain } from '../../features/Main'
+import Picture from '../..//features/Picture/Picture'
+import Header from '../../features/Header'
+import Footer from '../../features/Footer'
+import { URL } from '../../utils/url'
+import { StyledCard as BaseStyledCard } from '../../features/Card'
 import type { ResumeEverythingType } from '../../typings'
-import { StyledGrid, StyledLeaderBoard } from './styled'
-import { renderWork } from './PortfolioPage'
+import { StyledLeaderBoard, StyledCardImage } from './styled'
+import { FigCaption } from './PortfolioPage'
 
-/**
- * @file @name PortfolioWorkExperienceItemPage
- */
+const StyledFooter = styled(Footer)``
+
+const StyledHeader = styled(Header)`
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 4px rgb(0 0 0 / 50%);
+
+  body:not(.dark-mode) & {
+    background-color: #6200eef2;
+  }
+  body.dark-mode & {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+
+  @media (max-width: 480px) {
+    height: 4rem;
+  }
+`
+
+const centerH1 = css`
+  top: 0;
+  font-size: 4rem;
+  font-weight: 500;
+  backdrop-filter: blur(4px);
+  z-index: 3;
+  padding: 2rem;
+  background-color: rgba(52, 73, 85, 0.01);
+  text-align: center;
+`
+
+const StyledH1 = styled.h1`
+  > span {
+    position: sticky;
+    z-index: 1;
+    transform: translateZ(0);
+  }
+
+  ${centerH1};
+  overflow: hidden;
+  transform: translateZ(0);
+  text-align: center;
+  font-size: 4rem;
+  font-weight: 300;
+  color: var(--theme-card-header);
+  text-shadow: 0 1px 0 rgb(255 255 255 / 55%), 0 4px 0 rgb(0 0 0 / 10%),
+    0 5px 0 rgb(0 0 0 / 10%), 0 4px 0 rgb(0 0 0 / 10%);
+  min-width: 100%;
+  margin: 0;
+  background-color: transparent;
+`
+
+const StyledLeaderBoardColoured = styled(StyledLeaderBoard)`
+  position: relative;
+  background-color: var(--theme-card-background);
+  padding: 0;
+  margin: 0;
+  padding-top: 3rem;
+  position: relative;
+  background-color: transparent;
+
+  picture {
+    max-height: 70vh;
+    overflow-y: scroll;
+    -webkit-box-reflect: above;
+    background: var(--theme-card-figcaption-background);
+  }
+  @media (max-width: 1024px) {
+    picture {
+      max-height: 20vh;
+    }
+    ${StyledH1} {
+      font-size: 2rem;
+    }
+  }
+
+  ${StyledCardImage} {
+    height: unset;
+    min-width: 100%;
+  }
+`
+
+/** @todo hiding header because the same content is shown in the h1. improve the accessibility and semantics of this approach. */
+const StyledCard = styled(BaseStyledCard)`
+  &&& {
+    margin-bottom: 2rem;
+    padding: 0;
+  }
+
+  figure {
+    margin: 0;
+    padding: 0;
+    header {
+      display: none;
+    }
+  }
+  @media (min-width: 1024px) {
+    figure {
+      padding: 2rem 1.5rem 1.75rem 1.5rem;
+    }
+  }
+  @media (min-width: 1200px) {
+    figure {
+      padding: 3rem 2rem 2.5rem 2rem;
+    }
+  }
+  @media (min-width: 1600px) {
+    figure {
+      padding: 3rem 2rem 2.5rem 2rem;
+    }
+  }
+`
+
+/** @todo move to another file, make re-usable */
+const changeQualitySearchParam = (src: string) => {
+  const srcUrl = new URL(src)
+  srcUrl.searchParams.set('q', '80')
+  return srcUrl.href
+}
+
 export default React.memo(function PortfolioWorkExperienceItemPage({
   person,
   work,
@@ -31,11 +152,12 @@ export default React.memo(function PortfolioWorkExperienceItemPage({
   return (
     <>
       <PortfolioHead
-        titleText={`${person.name}'s Portfolio - ${workItem.company}`}
-        description={person.summary}
+        titleText={`${person.name} at ${workItem.company} as a ${workItem.position}`}
         {...person}
         {...rest}
         image={workItem.image}
+        description={workItem.summary}
+        highlightsPicture={workItem.image}
       />
       <PortfolioSchema
         person={person}
@@ -43,12 +165,49 @@ export default React.memo(function PortfolioWorkExperienceItemPage({
         openSource={openSource}
         workIndex={index}
       />
+      <StyledHeader name={person.name} />
       <StyledMain>
-        <StyledLeaderBoard>
-          <h1>{workItem.company}</h1>
-        </StyledLeaderBoard>
-        <StyledGrid>{renderWork(workItem, index)}</StyledGrid>
+        <StyledLeaderBoardColoured>
+          <StyledH1>
+            <span>{workItem.company}</span>
+          </StyledH1>
+          <Picture
+            image={{
+              ...workItem.image,
+              srcSizes: workItem.image.srcSizes.filter(([media]) => {
+                if (
+                  media.includes(' 800') ||
+                  media.includes(' 600') ||
+                  media.includes(' 480')
+                ) {
+                  return false
+                }
+                return true
+              }),
+            }}
+            RenderImage={imgProps => {
+              const src = changeQualitySearchParam(imgProps.src as string)
+              return (
+                <StyledCardImage
+                  loading={index === 0 ? 'eager' : 'lazy'}
+                  {...imgProps}
+                  src={src}
+                  // @todo use sizes param to check ratio
+                  // srcSizes={workItem.image.srcSizes}
+                />
+              )
+            }}
+          />
+        </StyledLeaderBoardColoured>
+        <>
+          <StyledCard>
+            <figure>
+              <FigCaption work={workItem} />
+            </figure>
+          </StyledCard>
+        </>
       </StyledMain>
+      <StyledFooter name={person.name} openSource={openSource} />
     </>
   )
 })

--- a/src/pages/Portfolio/ExperiencePage.tsx
+++ b/src/pages/Portfolio/ExperiencePage.tsx
@@ -208,6 +208,7 @@ export default React.memo(function PortfolioWorkExperienceItemPage({
             <span>{workItem.company}</span>
           </StyledH1>
           <Picture
+            tabIndex="0"
             RenderPicture={CustomPictureWithAmpSupport}
             image={{
               ...workItem.image,

--- a/src/pages/Portfolio/ExperiencePage.tsx
+++ b/src/pages/Portfolio/ExperiencePage.tsx
@@ -207,7 +207,12 @@ export default React.memo(function PortfolioWorkExperienceItemPage({
           </StyledCard>
         </>
       </StyledMain>
-      <StyledFooter name={person.name} openSource={openSource} />
+      <StyledFooter
+        name={person.name}
+        resumeWebsite={person.resumeWebsite}
+        profiles={person.profiles}
+        openSource={openSource}
+      />
     </>
   )
 })

--- a/src/pages/Portfolio/ExperiencePage.tsx
+++ b/src/pages/Portfolio/ExperiencePage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { useRouter } from 'next/router'
+import { useAmp } from 'next/amp'
 import PortfolioSchema from '../../features/PortfolioSchema'
 import PortfolioHead from '../../features/PortfolioHead'
 import { StyledMain } from '../../features/Main'
@@ -8,10 +9,35 @@ import Picture from '../..//features/Picture/Picture'
 import Header from '../../features/Header'
 import Footer from '../../features/Footer'
 import { URL } from '../../utils/url'
+import { StyledPicture } from '../../features/Picture/Picture'
 import { StyledCard as BaseStyledCard } from '../../features/Card'
 import type { ResumeEverythingType } from '../../typings'
 import { StyledLeaderBoard, StyledCardImage } from './styled'
 import { FigCaption } from './PortfolioPage'
+
+const StyledAmpPicture = styled.div`
+  height: 100vh;
+  width: 100vw;
+  max-height: 40vh;
+  overflow-y: scroll;
+  -webkit-box-reflect: above;
+  background: var(--theme-card-figcaption-background);
+  @media (max-width: 1024px) {
+    max-height: 20vh;
+    height: 50vh;
+  }
+`
+
+const CustomPictureWithAmpSupport = (
+  props: React.ComponentProps<typeof StyledPicture>
+) => {
+  const isAmp = useAmp()
+  if (isAmp) {
+    return <StyledAmpPicture>{props.children}</StyledAmpPicture>
+  } else {
+    return <StyledPicture {...props} />
+  }
+}
 
 const StyledFooter = styled(Footer)``
 
@@ -79,14 +105,23 @@ const StyledLeaderBoardColoured = styled(StyledLeaderBoard)`
     background: var(--theme-card-figcaption-background);
   }
   @media (max-width: 1024px) {
+    padding-top: 2rem;
     picture {
-      max-height: 20vh;
+      max-height: 35vh;
     }
     ${StyledH1} {
       font-size: 2rem;
+      padding-bottom: 0.5rem;
     }
   }
-
+  @media (max-width: 480px) {
+    &&& {
+      padding-top: 2rem;
+    }
+    ${StyledH1} {
+      font-size: 1.5rem;
+    }
+  }
   ${StyledCardImage} {
     height: unset;
     min-width: 100%;
@@ -140,6 +175,7 @@ export default React.memo(function PortfolioWorkExperienceItemPage({
   const {
     query: { pid = -42 },
   } = useRouter()
+  const isAmp = useAmp()
   const pidIndex = work?.findIndex(({ id }) => id == pid)
   const index: number = Number(pidIndex)
   const workItem = work?.[index]
@@ -172,6 +208,7 @@ export default React.memo(function PortfolioWorkExperienceItemPage({
             <span>{workItem.company}</span>
           </StyledH1>
           <Picture
+            RenderPicture={CustomPictureWithAmpSupport}
             image={{
               ...workItem.image,
               srcSizes: workItem.image.srcSizes.filter(([media]) => {

--- a/src/pages/Portfolio/PortfolioPage.tsx
+++ b/src/pages/Portfolio/PortfolioPage.tsx
@@ -19,18 +19,52 @@ import {
 import TimeRange from './TimeRange'
 import AmpStyles from './AmpStyles'
 
+export const FigCaption = React.memo(function FigCaption({
+  work,
+}: {
+  work: WorkType
+}) {
+  const isAmp = useAmp()
+  const fx = React.useMemo(
+    () =>
+      isAmp ? { 'amp-fx': 'parallax', 'data-parallax-factor': '1.19' } : {},
+    [isAmp]
+  )
+  return (
+    <figcaption {...fx}>
+      <header>{work.company}</header>
+      <section>
+        <strong>{work.position}</strong>
+        {typeof work.highlights === 'string' &&
+        work.highlights.includes('- ') ? (
+          <ul key="highlights">
+            {work.highlights
+              .split('- ')
+              .filter(Boolean)
+              .map(highlight => (
+                <li key={highlight}>{highlight}</li>
+              ))}
+          </ul>
+        ) : (
+          <p key="highlights">{work.highlights}</p>
+        )}
+        <p>{work.summary}</p>
+        <StyledLink to={work.website}>{work.website}</StyledLink>
+      </section>
+      <StyledExperienceSection>
+        <StyledLink to={`/Portfolio/Experience/${work.id}`}>
+          <TimeRange startDate={work.startDate} endDate={work.endDate} />
+        </StyledLink>
+      </StyledExperienceSection>
+    </figcaption>
+  )
+})
+
 export function renderWork(work: WorkType, index: number) {
   const isAmp = useAmp()
   const fx = React.useMemo(
     () =>
-      ({
-        card: isAmp
-          ? { 'amp-fx': 'parallax', 'data-parallax-factor': '1.15' }
-          : {},
-        caption: isAmp
-          ? { 'amp-fx': 'parallax', 'data-parallax-factor': '1.19' }
-          : {},
-      } as const),
+      isAmp ? { 'amp-fx': 'parallax', 'data-parallax-factor': '1.15' } : {},
     [isAmp]
   )
 
@@ -44,36 +78,11 @@ export function renderWork(work: WorkType, index: number) {
               loading={index === 0 ? 'eager' : 'lazy'}
               {...imgProps}
               srcSizes={work.image.srcSizes}
-              {...fx.card}
+              {...fx}
             />
           )}
-        ></Picture>
-        <figcaption {...fx.caption}>
-          <header>{work.company}</header>
-          <section>
-            <strong>{work.position}</strong>
-            {typeof work.highlights === 'string' &&
-            work.highlights.includes('- ') ? (
-              <ul key="highlights">
-                {work.highlights
-                  .split('- ')
-                  .filter(Boolean)
-                  .map(highlight => (
-                    <li key={highlight}>{highlight}</li>
-                  ))}
-              </ul>
-            ) : (
-              <p key="highlights">{work.highlights}</p>
-            )}
-            <p>{work.summary}</p>
-            <StyledLink to={work.website}>{work.website}</StyledLink>
-          </section>
-          <StyledExperienceSection>
-            <StyledLink to={`/Portfolio/Experience/${work.id}`}>
-              <TimeRange startDate={work.startDate} endDate={work.endDate} />
-            </StyledLink>
-          </StyledExperienceSection>
-        </figcaption>
+        />
+        <FigCaption work={work} />
       </StyledCardFigure>
     </StyledCard>
   )

--- a/src/pages/Portfolio/PortfolioPage.tsx
+++ b/src/pages/Portfolio/PortfolioPage.tsx
@@ -127,7 +127,12 @@ export function PortfolioPage({
           {work.map(renderWork)}
         </StyledGrid>
       </StyledMain>
-      <Footer name={person.name} openSource={openSource} />
+      <Footer
+        openSource={openSource}
+        name={person.name}
+        resumeWebsite={person.resumeWebsite}
+        profiles={person.profiles}
+      />
     </>
   )
 }

--- a/src/pages/Portfolio/styled.tsx
+++ b/src/pages/Portfolio/styled.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import AmpCompatImage from '../../features/Picture/Image'
 import { StyledLink as BaseStyledLink } from '../../features/Link'
 import Header from '../../features/Header'
@@ -14,7 +14,7 @@ export const StyledGrid = styled.div`
   grid-auto-rows: auto;
 
   @media (max-width: 420px) {
-    padding: 0;
+    padding: 0.5rem;
   }
 `
 

--- a/src/utils/fromReqToUrl.ts
+++ b/src/utils/fromReqToUrl.ts
@@ -11,7 +11,7 @@ import { URL } from './url'
  */
 export function fromReqToUrl(
   req: ExpressRequest & { url?: string; headers: UnknownObj }
-): typeof URL {
+): URL {
   if (req === undefined) {
     if (process.browser) {
       if (process.env.NODE_ENV === 'development') {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -4,7 +4,10 @@
  * could use ponyfill instead
  */
 
-export const URL = !process.browser ? require('url').URL : globalThis.URL
-export const URLSearchParams = !process.browser
+export const URL: typeof globalThis.URL = !process.browser
+  ? require('url').URL
+  : globalThis.URL
+
+export const URLSearchParams: typeof globalThis.URLSearchParams = !process.browser
   ? require('url').URLSearchParams
   : globalThis.URLSearchParams


### PR DESCRIPTION
### Feat
- Glassmorphism on home page.
- Redesign experience-item pages. This includes WCAG & ADA checks. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-08f361882e07922e5c16f64d3eb8a59e5d2b91df3d44cb34ab022cd9f0aa5179R18)

### Minor
- Set explicit typings on URL polyfills util exports. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-aab4ceb6d3254a7b948f95d8057cd8d91cd43c09f95569885cbce6d8b079d926R7)
- Show social profiles in the footer for non-home pages.
- Fix email breaking to new line on smaller screens. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-f6ff79a2ecafebb7adb3c2ce44e2091b4c8cf140ac0761b675079717fef31760R32)
- Refactor: split FigCaption into a component. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-886c9f541201f388419d36cc2b7e5e156e369f638b4c04dd7e182726439418cfR22)

### Todos 
_To be covered outside of this CR_.

#### More
- [ ] Better hiding for header on experience pages. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-08f361882e07922e5c16f64d3eb8a59e5d2b91df3d44cb34ab022cd9f0aa5179R131)
- [ ] Image performance on experience-item pages. `srcsizes` are currently commented out and should be updated. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-08f361882e07922e5c16f64d3eb8a59e5d2b91df3d44cb34ab022cd9f0aa5179R233)
#### Less
- [ ] Colour contrast real-world veritifcation. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-46bb5eb26ff6dab40dcb86df65cf157e37bf4756d7c73324fff8e2df0614b94bR18)
- [ ] Double check HTML semantics vs ADA on aside elements. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-795aa5260ea728229834125c2b33e22fd2bcb3384d315ef95569ad9dd5e5f0aeR16)
- [ ] Make URL param util in the experience-item page re-usable/shared/moved-to-its-own-file. [code](https://github.com/aretecode/modern-stack-portfolio-react/compare/2021?expand=1#diff-08f361882e07922e5c16f64d3eb8a59e5d2b91df3d44cb34ab022cd9f0aa5179R162)